### PR TITLE
Fix crash after finish called on watcher

### DIFF
--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -26,6 +26,7 @@ module Kubeclient
             buffer << chunk
             while (line = buffer.slice!(/.+\n/))
               yield @format == :json ? WatchNotice.new(JSON.parse(line)) : line.chomp
+              return if @finished
             end
           end
         end


### PR DESCRIPTION
Proposed fix to the issue causing Samson to crash after a k8s cluster deployment.

When finish is called on the watcher, the connection is closed and the socket is set to nil. The #each loop however still tries to read data from the socket which causes the crash.

This is a very naive approach but it works. I'm also yet to figure out a nice way to test it. The HTTP calls are mocked out in the tests so we don't see problems with the socket being nil.

If we agree that this in fact is a problem with the upstream gem and not our implementation, I'll create an issue in the original project.

/cc @jonmoter @henders @sbrnunes 
### References
- Jira link: 
### Risks
- None
